### PR TITLE
Fix tag error when a user tries to get a post with a nonexistent user

### DIFF
--- a/data/helpers/postDb.js
+++ b/data/helpers/postDb.js
@@ -6,7 +6,7 @@ module.exports = {
 
     if (id) {
       query
-        .join('users as u', 'p.userId', 'u.id')
+        .leftOuterJoin('users as u', 'p.userId', 'u.id')
         .select('p.text', 'u.name as postedBy')
         .where('p.id', id);
 


### PR DESCRIPTION
This fixes an error students where students get the following error:

error TypeError: Cannot set property 'tags' of undefined
    at /Users/Frank/src/lambdaSchool/Node-Blog/data/helpers/postDb.js:18:19
    at <anonymous>

when trying to get a post with an id from a deleted userId